### PR TITLE
Check candidates before using Vertex AI response

### DIFF
--- a/src/main/java/genai/GenAIService.java
+++ b/src/main/java/genai/GenAIService.java
@@ -15,8 +15,21 @@ public class GenAIService {
     GenAIService(GenerativeModel generativeModel) {
         this.generativeModel = generativeModel;
     }
+    /**
+     * Generates text for the supplied prompt using Vertex AI.
+     * <p>
+     * If Vertex AI does not return any candidates this method returns an empty
+     * string.
+     *
+     * @param prompt text prompt to send to Vertex AI
+     * @return generated text or an empty string when no candidates are returned
+     * @throws IOException if an error occurs communicating with Vertex AI
+     */
     public String generateTextWithVertexAI(String prompt) throws IOException {
         GenerateContentResponse response = generativeModel.generateContent(prompt);
+        if (response.getCandidatesCount() == 0) {
+            return "";
+        }
         return response.getCandidates(0).getContent().getParts(0).getText();
     }
 


### PR DESCRIPTION
## Summary
- add Javadoc for `generateTextWithVertexAI`
- handle empty candidate list by returning an empty string

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f77725354832385bf13194b9b51c6