### PR TITLE
Add JUnit tests for GenAIService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>google-ai-connect</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-vertexai</artifactId>
+            <version>0.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.2.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/java/genai/GenAIServiceTest.java
+++ b/src/test/java/genai/GenAIServiceTest.java
@@ -1,0 +1,65 @@
+package genai;
+
+import com.google.cloud.vertexai.api.Candidate;
+import com.google.cloud.vertexai.api.Content;
+import com.google.cloud.vertexai.api.GenerateContentResponse;
+import com.google.cloud.vertexai.api.Part;
+import com.google.cloud.vertexai.generativeai.preview.GenerativeModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GenAIServiceTest {
+
+    @Mock
+    private GenerativeModel generativeModel;
+    @Mock
+    private GenerateContentResponse response;
+    @Mock
+    private Candidate candidate;
+    @Mock
+    private Content content;
+    @Mock
+    private Part part;
+
+    private GenAIService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new GenAIService(generativeModel);
+    }
+
+    @Test
+    void generateTextWithVertexAI_returnsCandidateText() throws IOException {
+        when(generativeModel.generateContent("prompt")).thenReturn(response);
+        when(response.getCandidatesCount()).thenReturn(1);
+        when(response.getCandidates(0)).thenReturn(candidate);
+        when(candidate.getContent()).thenReturn(content);
+        when(content.getParts(0)).thenReturn(part);
+        when(part.getText()).thenReturn("expected text");
+
+        String result = service.generateTextWithVertexAI("prompt");
+        assertEquals("expected text", result);
+    }
+
+    @Test
+    void generateTextWithVertexAI_emptyCandidatesReturnsEmptyString() throws IOException {
+        when(generativeModel.generateContent(anyString())).thenReturn(response);
+        when(response.getCandidatesCount()).thenReturn(0);
+
+        String result = service.generateTextWithVertexAI("prompt");
+        assertEquals("", result);
+        verify(response, never()).getCandidates(anyInt());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `pom.xml` so the project can build with Maven
- create `GenAIServiceTest` verifying successful and empty responses

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f784a8080832383c3f42b4a9706a0